### PR TITLE
Remove unneeded package

### DIFF
--- a/fitnessplatform/settings.py
+++ b/fitnessplatform/settings.py
@@ -43,7 +43,6 @@ INSTALLED_APPS = [
     'apps.trainers',
     'apps.users',
     'bootstrap4',
-    'crispy_forms',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -68,7 +67,9 @@ ROOT_URLCONF = 'fitnessplatform.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [str(BASE_DIR) + '/templates/', ],
+        'DIRS': [
+            str(BASE_DIR) + '/templates/',
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -80,8 +81,6 @@ TEMPLATES = [
         },
     },
 ]
-
-CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 WSGI_APPLICATION = 'fitnessplatform.wsgi.application'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ defusedxml==0.6.0
 Django==3.1.4
 django-allauth==0.44.0
 django-bootstrap4==2.3.1
-django-crispy-forms==1.10.0
 django-environ==0.4.5
 environ==1.0
 idna==2.10

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load crispy_forms_tags %}
+{% load bootstrap4 %}
 {% load i18n %}
 
 {% block content %}
@@ -12,7 +12,7 @@
 
 <form class="login" method="POST" action="{% url 'account_login' %}">
   {% csrf_token %}
-  {{ form|crispy }}
+  {% bootstrap_form form %}
   {% if redirect_field_value %}
     <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load crispy_forms_tags %}
+{% load bootstrap4 %}
 {% load i18n %}
 
 {% block content %}
@@ -16,7 +16,7 @@
     <p>{% trans 'Please contact us if you have any trouble resetting your password.' %}</p>
     <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
         {% csrf_token %}
-        {{ form|crispy }}
+        {% bootstrap_form form %}
         <input type="submit" class="btn btn-success" value="{% trans 'Reset Password' %}" />
     </form>
   </div>

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load crispy_forms_tags %}
+{% load bootstrap4 %}
 {% load i18n %}
 
 {% block content %}
@@ -10,7 +10,7 @@
     <p>{% trans 'Otherwise please fill in the form to be registered as a trainer on our platform.' %}</p>
     <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
       {% csrf_token %}
-      {{ form|crispy}}
+      {% bootstrap_form form %}
       {% if redirect_field_value %}
         <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
       {% endif %}


### PR DESCRIPTION
Wir können bootstrap_form anstelle von crispy_form benutzen und sparen uns so ein package.

* uninstall django-crispy-forms (das muss manuell gemacht werden, wenn es in der venv schon installiert war)
* kurz alle forms überprüfen (register/login/password reset) - die sollten immernoch so aussehen wie vorher