### PR TITLE
Enable static resources on prod

### DIFF
--- a/fitnessplatform/settings.py
+++ b/fitnessplatform/settings.py
@@ -146,6 +146,8 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+STATIC_ROOT = os.path.join(BASE_DIR, "assets")
+
 ROOT_PATH = os.path.dirname(__file__)
 STATICFILES_DIRS = [os.path.join(ROOT_PATH, '../static')]
 


### PR DESCRIPTION
Die static resources können jetzt auf Prod geladen werden: https://trainhorizon.eu.pythonanywhere.com/
Dazu musste ich STATIC_ROOT in den settings.py hinzufügen. Damit die Assets für die App bereitstehen, müssen diese nach jedem Upload von neuen statischen Resourcen auf dem Server migriert werden. Dabei sucht sich der Server alle Ressourcen und sammelt sie in einem Ordner` /assets` . Dieser muss leer sein, weswegen nicht `/static `verwendet werden kann. Zusätzlich zu unseren hinterlegten Assets werden hier auch noch die Ressourcen für den Admin-Bereich hinterlegt.

Ich denke, wir sollten bei Gelegenheit schon mal anfangen, ein paar Dummy-Daten einzupflegen, damit man besser abschätzen kann, ob auch alles richtig funktioniert. 
Superuser habe ich schon erstellt.